### PR TITLE
Update download link that 404's on main web page

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
                 <li class="pure-menu-item"><a href="http://rocknsm.io" class="pure-menu-link"><i class="fa fa-home fa-sm" aria-hidden="true"></i> Home</a></li>
 		<li class="pure-menu-item"><a href="https://blog.rocknsm.io" class="pure-menu-link"><i class="fa fa-edit" aria-hidden="true"></i> Blog</a></li>
 
-		<li class="pure-menu-item" class="pure-menu-item"><a href="https://download.rocknsm.io/isos/stable/" class="pure-menu-link"><i class="fa fa-download fa-sm" aria-hidden="true"></i> Download</a></li>
+		<li class="pure-menu-item" class="pure-menu-item"><a href="https://download.rocknsm.io/isos/testing/" class="pure-menu-link"><i class="fa fa-download fa-sm" aria-hidden="true"></i> Download</a></li>
                 <li class="pure-menu-item"><a href="https://docs.rocknsm.io" class="pure-menu-link"><i class="fa fa-book fa-sm" aria-hidden="true"></i> Documentation</a></li>
 
 


### PR DESCRIPTION
The "Download" button on the main web page links to /isos/stable/, which does not exist and results in a 404 error, so it should rather link to /isos/testing/, which is where the current isos reside.